### PR TITLE
Added Twital Bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Table of contents:
  * [TwigExtraBundle](https://github.com/csanquer/TwigExtraBundle) - Twig Extra Tools Extensions.
  * [TwigJackBundle](https://github.com/boekkooi/TwigJackBundle) - Handy additional features for Twig.
  * [UcoTwigExtensionsBundle](https://github.com/sgomez/UcoTwigExtensionsBundle) - Provides some filters.
+ * [TwitalBundle](https://github.com/goetas/twital-bundle) - An attribute template engine built on top of Twig and 100% compatible with all twig's features.
 
 ## Storage
 


### PR DESCRIPTION
Added Twital template engine. 
It is a bundle for https://github.com/goetas/twital . A template engine built on top of Twig and 100% with all twig's features (functions, filters, modifiers, extensions...)

It looks like PHPTal, but 100% Twig and Symfony compatible (you can use all Twig extensions from Twital, without porting them).